### PR TITLE
use earthly for helm testing instead of gitub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,29 +17,11 @@ jobs:
 
   helm-test:
     runs-on: ubuntu-latest
-    env:
-      HELM_VERSION: 3.10.2
-      HELM_UNITTEST_VERSION: 0.2.8
-      KUBECONFORM_VERSION: 0.5.0
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: supplypike/setup-bin@v1
+      - uses: earthly/actions-setup@v1
         with:
-          uri: https://github.com/yannh/kubeconform/releases/download/v${{ env.KUBECONFORM_VERSION }}/kubeconform-linux-amd64.tar.gz
-          name: kubeconform
-          version: ${{ env.KUBECONFORM_VERSION }}
+          version: v0.6.30
 
-      - uses: supplypike/setup-bin@v1
-        with:
-          uri: https://get.helm.sh/helm-v${{ env.HELM_VERSION }}-linux-amd64.tar.gz
-          name: helm
-          version: ${{ env.HELM_VERSION }}
+      - uses: actions/checkout@v3
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.0
-
-      - run: helm plugin install --version "${{ env.HELM_UNITTEST_VERSION }}" https://github.com/quintush/helm-unittest
-
-      - run: ct --config ./.github/ct.yaml lint ./charts --all
+      - run: earthly +helm-test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+# asdf plugin add earthly https://github.com/YR-ZR0/asdf-earthly
+earthly 0.6.30
+golang 1.19.3

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,29 @@
+VERSION 0.6
+
+helm-test:
+    ARG ct_args=''
+    FROM quay.io/helmpack/chart-testing:v3.7.1
+
+    ARG KUBECONFORM_VERSION="0.5.0"
+    ARG HELM_UNITTEST_VERSION="0.2.8"
+
+    # install kubeconform
+    RUN FILE=kubeconform.tgz \
+        && URL=https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz \
+        && wget ${URL} \
+            --output-document ${FILE} \
+        && tar \
+            --extract \
+            --verbose \
+            --directory /bin \
+            --file ${FILE} \
+        && kubeconform -v
+
+    RUN apk add --no-cache bash git \
+        && helm plugin install --version "${HELM_UNITTEST_VERSION}" https://github.com/quintush/helm-unittest \
+        && helm unittest --help
+
+    # actually lint the chart
+    WORKDIR /src
+    COPY . /src
+    RUN ct --config ./.github/ct.yaml lint ./charts --all


### PR DESCRIPTION
worse? better? you be the judge!

pros:
- dockerfile-like syntax, easy to pick up
- avoid github action and the commit/push/wait/find error/resolve error/repeat CI cycle
- easily executable locally

cons:
- one more tool (only necessary if you want to test locally though)
- one more file format to learn (but mostly docker? mostly?)
- requires some extra start up (23 seconds vs 32 seconds for this build)