### PR TITLE
add quick logic for jobs to be passed in the uri path

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -100,7 +100,7 @@ func (a *aggregate) saveFamily(familyName string, family *dto.MetricFamily) erro
 	return nil
 }
 
-func (a *aggregate) parseAndMerge(r io.Reader) error {
+func (a *aggregate) parseAndMerge(r io.Reader, job string) error {
 	var parser expfmt.TextParser
 	inFamilies, err := parser.TextToMetricFamilies(r)
 	if err != nil {
@@ -110,7 +110,7 @@ func (a *aggregate) parseAndMerge(r io.Reader) error {
 	for name, family := range inFamilies {
 		// Sort labels in case source sends them inconsistently
 		for _, m := range family.Metric {
-			a.formatLabels(m)
+			a.formatLabels(m, job)
 		}
 
 		if err := validateFamily(family); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.8.1
-	github.com/go-playground/assert/v2 v2.0.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.3.0

--- a/labels.go
+++ b/labels.go
@@ -12,7 +12,22 @@ func strPtr(s string) *string {
 
 }
 
-func (a *aggregate) formatLabels(m *dto.Metric) {
+var JobLabel = strPtr("job")
+
+func addJobLabel(m *dto.Metric, job string) {
+	if len(m.Label) > 0 {
+		for _, l := range m.Label {
+			if l.GetName() == "job" {
+				l.Value = strPtr(job)
+				return
+			}
+		}
+	}
+	m.Label = append(m.Label, &dto.LabelPair{Name: JobLabel, Value: strPtr(job)})
+}
+
+func (a *aggregate) formatLabels(m *dto.Metric, job string) {
+	addJobLabel(m, job)
 	sort.Sort(byName(m.Label))
 
 	if len(a.options.ignoredLabels) > 0 {

--- a/labels_test.go
+++ b/labels_test.go
@@ -20,7 +20,7 @@ func TestFormatLabels(t *testing.T) {
 			{},
 		},
 	}
-	a.formatLabels(m)
+	a.formatLabels(m, "test")
 
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing1"), Value: strPtr("value1")}, m.Label[0])
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing2"), Value: strPtr("value2")}, m.Label[1])
@@ -83,7 +83,7 @@ func BenchmarkFormatLabels(b *testing.B) {
 		a := newAggregate(AddIgnoredLabels(v.ignoredLabels...))
 		b.Run(fmt.Sprintf("metric_type_%s", v.inputName), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				a.formatLabels(v.m)
+				a.formatLabels(v.m, "test")
 			}
 		})
 	}

--- a/labels_test.go
+++ b/labels_test.go
@@ -22,9 +22,10 @@ func TestFormatLabels(t *testing.T) {
 	}
 	a.formatLabels(m, "test")
 
-	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing1"), Value: strPtr("value1")}, m.Label[0])
-	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing2"), Value: strPtr("value2")}, m.Label[1])
-	assert.Len(t, m.Label, 2)
+	assert.Equal(t, &dto.LabelPair{Name: strPtr("job"), Value: strPtr("test")}, m.Label[0])
+	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing1"), Value: strPtr("value1")}, m.Label[1])
+	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing2"), Value: strPtr("value2")}, m.Label[2])
+	assert.Len(t, m.Label, 3)
 
 }
 


### PR DESCRIPTION
Quick implementation for passed job name in URI to be added to metrics as labels, this is to prevent different metrics from clobbering together from different jobs.

Before Benchmark
```
pkg: prom-aggregation-gateway
BenchmarkConcurrentAggregate/metric_type_simpleGauge-10                   160633             76634 ns/op           87347 B/op       1313 allocs/op
BenchmarkConcurrentAggregate/metric_type_fullMetrics-10                    85020            141702 ns/op          194174 B/op       3773 allocs/op
BenchmarkConcurrentAggregate/metric_type_multiLabel-10                    228883             51287 ns/op           64626 B/op        673 allocs/op
BenchmarkConcurrentAggregate/metric_type_multiLabelIgnore-10              236571             50984 ns/op           65026 B/op        703 allocs/op
BenchmarkConcurrentAggregate/metric_type_labelFields-10                   229822             49480 ns/op           61830 B/op        553 allocs/op
BenchmarkConcurrentAggregate/metric_type_reorderedLabels-10               247396             48567 ns/op           63026 B/op        603 allocs/op
BenchmarkConcurrentAggregate/metric_type_ignoredLabels-10                 247699             48915 ns/op           64866 B/op        703 allocs/op
PASS
ok      prom-aggregation-gateway        88.855s
```

After Benchmark
```
pkg: prom-aggregation-gateway
BenchmarkConcurrentAggregate/metric_type_simpleGauge-10                   151737             80920 ns/op           90707 B/op       1403 allocs/op
BenchmarkConcurrentAggregate/metric_type_fullMetrics-10                    83394            149929 ns/op          197534 B/op       3893 allocs/op
BenchmarkConcurrentAggregate/metric_type_multiLabel-10                    212082             54311 ns/op           65425 B/op        693 allocs/op
BenchmarkConcurrentAggregate/metric_type_multiLabelIgnore-10              228790             51045 ns/op           66146 B/op        733 allocs/op
BenchmarkConcurrentAggregate/metric_type_labelFields-10                   251012             47880 ns/op           62790 B/op        583 allocs/op
BenchmarkConcurrentAggregate/metric_type_reorderedLabels-10               257607             50677 ns/op           64146 B/op        633 allocs/op
BenchmarkConcurrentAggregate/metric_type_ignoredLabels-10                 228663             49682 ns/op           65986 B/op        733 allocs/op
PASS
ok      prom-aggregation-gateway        89.613s
```

This was quick and dirty, this can be optimized. 