### PR TITLE
Run as Non-Root User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X ${GO_MOD_PATH}/config.CommitS
 
 # generate clean, final image for end users
 FROM alpine:3.16
-COPY --from=builder /build/prom-aggregation-gateway .
+COPY --chown=nobody:nogroup --from=builder /build/prom-aggregation-gateway .
+
+USER 65534
 
 # executable
 ENTRYPOINT [ "./prom-aggregation-gateway" ]

--- a/Earthfile
+++ b/Earthfile
@@ -54,6 +54,7 @@ build-image:
     FROM alpine:${ALPINE_VERSION}
     COPY +build-binary/prom-aggregation-gateway .
     ENV GIN_MODE=release
+    USER 65534
     ENTRYPOINT ["/prom-aggregation-gateway"]
     SAVE IMAGE --push ${image_name}:${version}
 


### PR DESCRIPTION
It's not possible to run the prebuilt images on a Kubernetes cluster that require pods to adhere to the [Restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) because the image runs as the root user.

This PR changes to using the unprivileged `nobody` user, similar to how the prometheus push gateway does it: https://github.com/prometheus/pushgateway/blob/master/Dockerfile#L14 