### PR TITLE
Add CORS header support on metrics PUT/POST.

### DIFF
--- a/routers/public.go
+++ b/routers/public.go
@@ -33,6 +33,7 @@ func setupAPIRouter(cfg ApiRouterConfig, agg *metrics.Aggregate, promConfig prom
 	} else {
 		corsConfig.AllowAllOrigins = true
 	}
+	corsHandler := cors.New(corsConfig)
 	cfg.authAccounts = processAuthConfig(cfg.Accounts)
 
 	metricsMiddleware := middleware.New(middleware.Config{
@@ -47,13 +48,15 @@ func setupAPIRouter(cfg ApiRouterConfig, agg *metrics.Aggregate, promConfig prom
 
 	neededHandlers := []gin.HandlerFunc{}
 
+	neededHandlers = append(neededHandlers, corsHandler)
+
 	if len(cfg.Accounts) > 0 {
 		neededHandlers = append(neededHandlers, gin.BasicAuth(cfg.authAccounts))
 	}
 
 	r.GET("/metrics",
 		mGin.Handler("getMetrics", metricsMiddleware),
-		cors.New(corsConfig),
+		corsHandler,
 		agg.HandleRender,
 	)
 


### PR DESCRIPTION
In the scenario where prom-aggregation-gateway is exposed to external client that writes metrics (so, browser for example) it should support adding CORS header (`Access-Control-Allow-Origin`) also on PUT/POST requests. This adds another layer of security (incorrect origins will be rejected) and allows matching origins to read the response from the gateway - browser client can confirm that metrics were indeed sent correctly.

Also added few simple router tests for GET and PUT with both failed and successful CORS.

Fixes https://github.com/zapier/prom-aggregation-gateway/issues/58