### PR TITLE
Don't allow adding duplicate labels through url

### DIFF
--- a/metrics/aggregate.go
+++ b/metrics/aggregate.go
@@ -119,7 +119,9 @@ func (a *Aggregate) parseAndMerge(r io.Reader, labels []labelPair) error {
 	for name, family := range inFamilies {
 		// Sort labels in case source sends them inconsistently
 		for _, m := range family.Metric {
-			a.formatLabels(m, labels)
+			if err := a.formatLabels(m, labels); err != nil {
+				return err
+			}
 		}
 
 		if err := validateFamily(family); err != nil {

--- a/metrics/labels_test.go
+++ b/metrics/labels_test.go
@@ -24,14 +24,18 @@ func TestFormatLabels(t *testing.T) {
 			{},
 		},
 	}
-	a.formatLabels(m, []labelPair{{"job", "test"}, {"thing3", "value3"}})
+	err := a.formatLabels(m, []labelPair{{"job", "test"}, {"thing3", "value3"}})
 
+	assert.Equal(t, err, nil)
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("job"), Value: strPtr("test")}, m.Label[0])
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing1"), Value: strPtr("value1")}, m.Label[1])
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing2"), Value: strPtr("value2")}, m.Label[2])
 	assert.Equal(t, &dto.LabelPair{Name: strPtr("thing3"), Value: strPtr("value3")}, m.Label[3])
 	assert.Len(t, m.Label, 4)
 
+	err = a.formatLabels(m, []labelPair{{"job", "test"}, {"thing3", "value3"}})
+
+	assert.Error(t, err)
 }
 
 var testLabelTable = []struct {

--- a/metrics/merge.go
+++ b/metrics/merge.go
@@ -170,6 +170,7 @@ func validateFamily(f *dto.MetricFamily) error {
 		if err := lSet.Validate(); err != nil {
 			return err
 		}
+
 		fingerprint := lSet.Fingerprint()
 		if _, found := fingerprints[fingerprint]; found {
 			return fmt.Errorf("duplicate labels: %v", lSet)


### PR DESCRIPTION
Hi, 

we've found that it's possible to add duplicate labels through url so here is a fix.

Hopefully, it'll be accepted. 🙂 

Thanks!