### PR TITLE
feat: merge summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prometheus Aggregation Gateway is a push gateway that aggregates metrics for Pro
 * Counters where all labels match are added up.
 * Histograms are added up; if bucket boundaries are mismatched then the result has the union of all buckets and counts are given to the lowest bucket that fits.
 * Gauges are also added up (but this may not make any sense)
-* Summaries are discarded.
+* Summaries are treated as a pair of counters (quantile information is discarded if present).
 
 ## How to use
 

--- a/metrics/aggregate_test.go
+++ b/metrics/aggregate_test.go
@@ -155,6 +155,16 @@ counter{b="b",a="a",ignore_me="ignored"} 2
 # TYPE counter counter
 counter{a="a",b="b",job="test"} 3
 `
+	summaryInput = `# HELP time_ms A summary
+# TYPE time_ms summary
+time_ms_sum{a="a",b="b"} 12.25
+time_ms_count{a="a",b="b"} 1.0
+`
+	summaryOutput = `# HELP time_ms A summary
+# TYPE time_ms summary
+time_ms_sum{a="a",b="b",job="test"} 24.5
+time_ms_count{a="a",b="b",job="test"} 2
+`
 )
 
 var testLabels = []labelPair{
@@ -176,6 +186,7 @@ func TestAggregate(t *testing.T) {
 		{"labelFields", labelFields1, labelFields2, labelFieldResult, []string{}},
 		{"reorderedLabels", reorderedLabels1, reorderedLabels2, reorderedLabelsResult, []string{}},
 		{"ignoredLabels", ignoredLabels1, ignoredLabels2, ignoredLabelsResult, []string{"ignore_me"}},
+		{"summary", summaryInput, summaryInput, summaryOutput, []string{}},
 	} {
 		t.Run(c.testName, func(t *testing.T) {
 			agg := NewAggregate(AddIgnoredLabels(c.ignoredLabels...))

--- a/metrics/merge.go
+++ b/metrics/merge.go
@@ -111,8 +111,14 @@ func mergeMetric(ty dto.MetricType, a, b *dto.Metric) *dto.Metric {
 		}
 
 	case dto.MetricType_SUMMARY:
-		// No way of merging summaries, abort.
-		return nil
+		// Treat Summary as a pair of counters, ignoring quantiles (which not all clients support anyway)
+		return &dto.Metric{
+			Label: a.Label,
+			Summary: &dto.Summary{
+				SampleCount: uint64ptr(*a.Summary.SampleCount + *b.Summary.SampleCount),
+				SampleSum:   float64ptr(*a.Summary.SampleSum + *b.Summary.SampleSum),
+			},
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Treat summaries as a pair of counters, and sum those counters. This ignores quantile information, but not all client libraries support those anyway. Comments welcome!

Fixes #5.