### PR TITLE
split alpine versions in build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.19-alpine3.16 as builder
+FROM golang:1.19-alpine3.17 as builder
 
 ARG COMMIT_SHA
 ARG VERSION_TAG
@@ -12,7 +12,7 @@ WORKDIR /build
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X ${GO_MOD_PATH}/config.CommitSHA=${COMMIT_SHA} -X ${GO_MOD_PATH}/config.Version=${VERSION_TAG}" -a -o prom-aggregation-gateway .
 
 # generate clean, final image for end users
-FROM alpine:3.16
+FROM alpine:3.17
 COPY --chown=nobody:nogroup --from=builder /build/prom-aggregation-gateway .
 
 USER 65534

--- a/Earthfile
+++ b/Earthfile
@@ -7,7 +7,8 @@ ARG commitSHA=""
 ARG version="dev"
 ARG PKG_PATH="github.com/zapier/prom-aggregation-gateway"
 
-ARG ALPINE_VERSION="3.17"
+ARG ALPINE_VERSION="3.17.5"
+ARG GOLANG_ALPINE_VERSION="3.17"
 ARG CHART_RELEASER_VERSION="1.4.1"
 ARG CHART_TESTING_VERSION="3.7.1"
 ARG GITHUB_CLI_VERSION="2.20.2"
@@ -35,7 +36,7 @@ release:
     BUILD +build-image
 
 go-deps:
-    FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
+    FROM golang:${GOLANG_VERSION}-alpine${GOLANG_ALPINE_VERSION}
 
     WORKDIR /src
     COPY go.mod go.sum /src
@@ -57,6 +58,7 @@ build-image:
     USER 65534
     ENTRYPOINT ["/prom-aggregation-gateway"]
     SAVE IMAGE --push ${image_name}:${version}
+    SAVE IMAGE --push ${image_name}:latest
 
 continuous-deploy:
     BUILD +build-helm


### PR DESCRIPTION
Splitting the Alpine Go build container Version and container runtime version to fix security issues documented in https://github.com/zapier/prom-aggregation-gateway/issues/69 

Before the build version and runtime version were set to alpine:3.17 since GoLang Alpine build container only has a tag for 3.17 wanted to make this independent for minor security bumps for the runtime containers.

Also adding latest tag to be pushed on deployments as the default helm charts reference the latest image tag
Referenced in https://github.com/zapier/prom-aggregation-gateway/issues/68