### PR TITLE
feat: Add additionalLabels support for Pod and Service Monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ helm repo update
 helm search repo pag -l
 ```
 
+### Helm Chart Unit Tests
+
+Helm plugin [quintush/helm-unittest](https://github.com/quintush/helm-unittest) is used for unit-testing.  
+After installing the plugin run `helm unittest <chart_dir>`. For Helm 3 support use `--helm3` flag.  
+More information on writing tests might be found in the plugin's project repo.
+
 ## Contributing
 To run the server you can run:
 

--- a/charts/prom-aggregation-gateway/Chart.yaml
+++ b/charts/prom-aggregation-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prom-aggregation-gateway
-version: 0.5.5
+version: 0.6.0
 home: https://github.com/zapier/prom-aggregation-gateway
 maintainers:
   - name: djeebus

--- a/charts/prom-aggregation-gateway/Chart.yaml
+++ b/charts/prom-aggregation-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prom-aggregation-gateway
-version: 0.5.3
+version: 0.5.5
 home: https://github.com/zapier/prom-aggregation-gateway
 maintainers:
   - name: djeebus

--- a/charts/prom-aggregation-gateway/templates/podmonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/podmonitor.yaml
@@ -3,6 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ .Release.Name }}-metrics
+{{- with .Values.podMonitor.additionalLabels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
@@ -3,6 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Release.Name }}
+{{- with .Values.serviceMonitor.additionalLabels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/prom-aggregation-gateway/tests/podmonitor_test.yaml
+++ b/charts/prom-aggregation-gateway/tests/podmonitor_test.yaml
@@ -1,0 +1,21 @@
+suite: PodMonitor tests
+
+templates: [podmonitor.yaml]
+
+tests:
+  - it: empty podmonitor labels by default
+    asserts:
+      - isEmpty:
+          path: metadata.labels
+  - it: can render podmonitor labels
+    set:
+      podMonitor:
+        additionalLabels:
+          hello: world
+          goodbye: moon
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            hello: world
+            goodbye: moon

--- a/charts/prom-aggregation-gateway/tests/servicemonitor_test.yaml
+++ b/charts/prom-aggregation-gateway/tests/servicemonitor_test.yaml
@@ -1,0 +1,21 @@
+suite: ServiceMonitor tests
+
+templates: [servicemonitor.yaml]
+
+tests:
+  - it: empty servicemonitor labels by default
+    asserts:
+      - isEmpty:
+          path: metadata.labels
+  - it: can render servicemonitor labels
+    set:
+      serviceMonitor:
+        additionalLabels:
+          hello: world
+          goodbye: moon
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            hello: world
+            goodbye: moon

--- a/charts/prom-aggregation-gateway/values.schema.json
+++ b/charts/prom-aggregation-gateway/values.schema.json
@@ -88,6 +88,10 @@
       "properties": {
         "create": {
           "type": "boolean"
+        },
+        "additionalLabels": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     },
@@ -97,6 +101,10 @@
       "properties": {
         "create": {
           "type": "boolean"
+        },
+        "additionalLabels": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     }

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -17,6 +17,7 @@ controller:
 
 podMonitor:
   create: true
+  additionalLabels: {}
 
 service:
   create: true
@@ -27,3 +28,4 @@ service:
 
 serviceMonitor:
   create: true
+  additionalLabels: {}


### PR DESCRIPTION
This MR adds:
- Optional `.serviceMonitor.additionalLabels`
- Optional `.podMonitor.additionalLabels`

`additionalLabels` provides an ability to properly discover Monitors using the `serviceMonitorSelector.matchLabels `and `podMonitorSelector.matchLabels` with the `prometheus-operator`