### PR TITLE
chore: add configurable pod annotation

### DIFF
--- a/charts/prom-aggregation-gateway/Chart.yaml
+++ b/charts/prom-aggregation-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prom-aggregation-gateway
-version: 0.6.0
+version: 0.6.1
 home: https://github.com/zapier/prom-aggregation-gateway
 maintainers:
   - name: djeebus

--- a/charts/prom-aggregation-gateway/templates/controller.yaml
+++ b/charts/prom-aggregation-gateway/templates/controller.yaml
@@ -20,6 +20,10 @@ spec:
   {{- end }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "prom-aggregation-gateway.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -21,6 +21,8 @@ podMonitor:
   create: true
   additionalLabels: {}
 
+podAnnotations: {}
+
 service:
   create: true
   annotations: {}


### PR DESCRIPTION
Useful in cases with the CA
```
podAnnotations:
  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
```
cc: @mplachter @djeebus 