### PR TITLE
Clear gauges on prometheus scrape

### DIFF
--- a/.github/workflows/on_merge.yaml
+++ b/.github/workflows/on_merge.yaml
@@ -1,9 +1,10 @@
 name: continuous deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
 
 jobs:
   release-charts:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -68,6 +68,13 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Set lower case owner name
+        id: lower-case
+        run: |
+          echo "repository_owner=${OWNER,,}" >> ${GITHUB_OUTPUT}
+        env:
+          OWNER: ${{ github.repository_owner }}
+
       - name: Build and push the Docker image
         run: |
           ./earthly \
@@ -75,4 +82,4 @@ jobs:
             +build-image-multiarch \
               --version=${{ env.RELEASE_VERSION }} \
               --commitSHA=${{ env.SHORT_SHA }} \
-              --image_name=ghcr.io/${{ github.repository_owner }}/prom-aggregation-gateway
+              --image_name=ghcr.io/${{ steps.lower-case.outputs.repository_owner }}/prom-aggregation-gateway

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Install Go
+
+https://golang.org/doc/install
+
+## Install dependencies
+
+```sh
+go mod tidy
+```
+
+## Run
+
+```sh
+go run . --apiListen 127.0.0.1:8080
+```
+
+## Send some metrics
+
+```
+echo "some_metric 3.14" | curl --data-binary @- http://127.0.0.1:8080/metrics/job/some_job
+
+printf "#TYPE another_metric gauge\nanother_metric 42\n" | curl --data-binary @- http://127.0.0.1:8080/metrics/job/some_job
+```
+
+## See your metric
+
+Open http://127.0.0.1:8080/metrics in your browser or use `curl`:
+
+```sh
+curl http://127.0.0.1:8080/metrics
+```
+
+Expected result
+
+```
+# TYPE another_metric gauge
+another_metric{job="some_job"} 42
+# TYPE some_metric untyped
+some_metric{job="some_job"} 3.14
+```
+
+## Simulate a scrape from Prometheus
+
+-   With "Prometheus/1.0" as user-agent
+-   Gauges will be cleared after the scrape
+
+```sh
+curl -H "User-Agent: Prometheus/1.0" http://127.0.0.1:8080/metrics
+```
+
+Returns the same as above. But if executed again, the `gauge` metrics are cleared:
+
+```
+# TYPE some_metric untyped
+some_metric{job="some_job"} 3.14
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ some_metric{job="some_job"} 3.14
 curl -H "User-Agent: Prometheus/1.0" http://127.0.0.1:8080/metrics
 ```
 
-Returns the same as above. But if executed again, the `gauge` metrics are cleared:
+Returns the same as above. But if executed again, `gauge` metrics are cleared:
 
 ```
 # TYPE some_metric untyped

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,9 @@ Returns the same as above. But if executed again, the `gauge` metrics are cleare
 # TYPE some_metric untyped
 some_metric{job="some_job"} 3.14
 ```
+
+## Run tests
+
+```sh
+go test ./...
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Prometheus Aggregation Gateway is a push gateway that aggregates metrics for Pro
 
 * Counters where all labels match are added up.
 * Histograms are added up; if bucket boundaries are mismatched then the result has the union of all buckets and counts are given to the lowest bucket that fits.
-* Gauges are also added up (but this may not make any sense)
+* Gauges are replaced
 * Summaries are treated as a pair of counters (quantile information is discarded if present).
 
 ## How to use

--- a/metrics/merge.go
+++ b/metrics/merge.go
@@ -82,13 +82,10 @@ func mergeMetric(ty dto.MetricType, a, b *dto.Metric) *dto.Metric {
 		}
 
 	case dto.MetricType_GAUGE:
-		// No very meaningful way for us to merge gauges.  We'll sum them
-		// and clear out any gauges on scrape, as a best approximation, but
-		// this relies on client pushing with the same interval as we scrape.
 		return &dto.Metric{
 			Label: a.Label,
 			Gauge: &dto.Gauge{
-				Value: float64ptr(*a.Gauge.Value + *b.Gauge.Value),
+				Value: float64ptr(*b.Gauge.Value),
 			},
 		}
 


### PR DESCRIPTION
When the user agent matches 'Prometheus/', gauges will be cleared after sending the response