### PR TITLE
HELM CHART: Adjusted k8s resources name

### DIFF
--- a/charts/prom-aggregation-gateway/templates/controller.yaml
+++ b/charts/prom-aggregation-gateway/templates/controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: {{ .Values.controller.type }}
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.nameOverride | default .Release.Name }}
   labels:
     {{- include "prom-aggregation-gateway.labels" . | nindent 4 }}
     {{- if .Values.controller.labels }}

--- a/charts/prom-aggregation-gateway/templates/podmonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/podmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: {{ .Values.nameOverride | default .Release.Name }}-metrics
 {{- with .Values.podMonitor.additionalLabels }}
   labels:
 {{- toYaml . | nindent 4 }}

--- a/charts/prom-aggregation-gateway/templates/service.yaml
+++ b/charts/prom-aggregation-gateway/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.nameOverride | default .Release.Name }}
   labels:
     {{- include "prom-aggregation-gateway.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.nameOverride | default .Release.Name }}
 {{- with .Values.serviceMonitor.additionalLabels }}
   labels:
 {{- toYaml . | nindent 4 }}

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -1,3 +1,4 @@
+nameOverride: ""
 controller:
   image:
     repository: ghcr.io/zapier/prom-aggregation-gateway


### PR DESCRIPTION
Hi! There's an issue with the Helm chart. The resource name uses `{{ .Release.Name }}`, which makes it inconvenient to use the chart as a dependency. Resources created by the chart inherit the main chart's name, making it difficult to identify the service or controller.  

The proposed pull request includes a fix that uses `{{ .Values.nameOverride | default .Release.Name }}` for resource names.