### PR TITLE
Improvements in name handling for the k8s object names

### DIFF
--- a/charts/prom-aggregation-gateway/templates/_helpers.tpl
+++ b/charts/prom-aggregation-gateway/templates/_helpers.tpl
@@ -30,12 +30,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some k8s name fields are limited to this (by the DNS naming spec).
-If the release name contains a chart name, it will be used as a full name.
+If the release name contains a chart name, then it will be used as a full name.
 */}}
 {{- define "prom-aggregation-gateway.fullname" -}}
-{{- if .Values.nameOverride }}
-{{- .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-prom-aggregator-gateway" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prom-aggregation-gateway/templates/_helpers.tpl
+++ b/charts/prom-aggregation-gateway/templates/_helpers.tpl
@@ -26,3 +26,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "prom-aggregation-gateway.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some k8s name fields are limited to this (by the DNS naming spec).
+If the release name contains a chart name, it will be used as a full name.
+*/}}
+{{- define "prom-aggregation-gateway.fullname" -}}
+{{- if .Values.nameOverride }}
+{{- .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-prom-aggregator-gateway" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/prom-aggregation-gateway/templates/controller.yaml
+++ b/charts/prom-aggregation-gateway/templates/controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: {{ .Values.controller.type }}
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "prom-aggregation-gateway.fullname" . }}
   labels:
     {{- include "prom-aggregation-gateway.labels" . | nindent 4 }}
     {{- if .Values.controller.labels }}

--- a/charts/prom-aggregation-gateway/templates/podmonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/podmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: {{ include "prom-aggregation-gateway.fullname" . }}
 {{- with .Values.podMonitor.additionalLabels }}
   labels:
 {{- toYaml . | nindent 4 }}

--- a/charts/prom-aggregation-gateway/templates/service.yaml
+++ b/charts/prom-aggregation-gateway/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "prom-aggregation-gateway.fullname" . }}
   labels:
     {{- include "prom-aggregation-gateway.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
+++ b/charts/prom-aggregation-gateway/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "prom-aggregation-gateway.fullname" . }}
 {{- with .Values.serviceMonitor.additionalLabels }}
   labels:
 {{- toYaml . | nindent 4 }}

--- a/charts/prom-aggregation-gateway/values.schema.json
+++ b/charts/prom-aggregation-gateway/values.schema.json
@@ -64,6 +64,9 @@
     "nameOverride": {
       "type": "string"
     },
+    "fullnameOverride": {
+      "type": "string"
+    },
     "service": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -35,3 +35,4 @@ serviceMonitor:
   additionalLabels: {}
 
 nameOverride: ""
+fullnameOverride: ""

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -33,3 +33,5 @@ service:
 serviceMonitor:
   create: true
   additionalLabels: {}
+
+nameOverride: ""


### PR DESCRIPTION
This helps when this chart is used as a dependency and there might be a conflict due to objects from the main chart having the same name. 