### PR TITLE
Add priorityClassName, networkPolicy, and imagePullSecrets option to chart

### DIFF
--- a/charts/prom-aggregation-gateway/templates/_helpers.tpl
+++ b/charts/prom-aggregation-gateway/templates/_helpers.tpl
@@ -26,3 +26,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "prom-aggregation-gateway.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "prom-aggregation-gateway.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion }}
+{{- print "extensions/v1beta1" }}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
+{{- print "networking.k8s.io/v1" }}
+{{- end }}
+{{- end }}

--- a/charts/prom-aggregation-gateway/templates/controller.yaml
+++ b/charts/prom-aggregation-gateway/templates/controller.yaml
@@ -60,6 +60,13 @@ spec:
           {{- with .Values.controller.resources }}
           resources: {{ . | toYaml | nindent 12 }}
           {{- end }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/prom-aggregation-gateway/templates/networkpolicy.yaml
+++ b/charts/prom-aggregation-gateway/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy }}
+apiVersion: {{ include "prom-aggregation-gateway.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "prom-aggregation-gateway.labels" . | nindent 4 }}
+  {{- if .Values.networkPolicy.customSelectors }}
+  name: ingress-allow-customselector-{{ template "prom-aggregation-gateway.name" . }}
+  {{- else if .Values.networkPolicy.allowAll }}
+  name: ingress-allow-all-{{ template "prom-aggregation-gateway.name" . }}
+  {{- else -}}
+  {{- fail "One of `allowAll` or `customSelectors` must be specified." }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "prom-aggregation-gateway.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      - port: {{ .Values.controller.apiPort }}
+      - port: {{ .Values.controller.lifecyclePort }}
+      {{- with .Values.networkPolicy.customSelectors }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/prom-aggregation-gateway/values.schema.json
+++ b/charts/prom-aggregation-gateway/values.schema.json
@@ -54,6 +54,12 @@
         },
         "tolerations": {
           "type": "array"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+	"imagePullSecrets": {
+          "type": "array"
         }
       },
       "required": [

--- a/charts/prom-aggregation-gateway/values.yaml
+++ b/charts/prom-aggregation-gateway/values.yaml
@@ -17,6 +17,9 @@ controller:
 
   nodeSelector: {}
 
+  # Optional pod imagePullSecrets
+  imagePullSecrets: []
+
 podMonitor:
   create: true
   additionalLabels: {}


### PR DESCRIPTION
Hi
I needed priority class and network policy options added to chart like it is present in the [prometheus-pushgateway](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-pushgateway) so I opened this pull request.