### PR TITLE
Fix docker builds and staticcheck install for GH actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-*
-!go.mod
-!go.sum
-!*.go
-dist

--- a/.github/workflows/on_pull_request_go.yaml
+++ b/.github/workflows/on_pull_request_go.yaml
@@ -22,6 +22,6 @@ jobs:
           go-version: "${{ env.GOLANG_TOOL_VERSION }}"
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@${{ env.STATICCHECK_TOOL_VERSION }}
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - run: make lint test-golang

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /prom-aggregation-gateway
 /.vscode
-/dist
+/_dist


### PR DESCRIPTION
Missed the `.dockerignore` file when updating the CI earlier, Docker images should now build successfully. 

Also using latest staticcheck version, old version was failing to install. 